### PR TITLE
chore: update gitattributes to ignore owlbot files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,8 @@
+/.OwlBot.yaml export-ignore
 /.gitattributes export-ignore
 /.github export-ignore
 /.gitignore export-ignore
 /dev export-ignore
-/tests export-ignore
 /phpunit.xml.dist export-ignore
+/owlbot.py export-ignore
+/tests export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,6 @@
 /.github export-ignore
 /.gitignore export-ignore
 /dev export-ignore
-/phpunit.xml.dist export-ignore
 /owlbot.py export-ignore
+/phpunit.xml.dist export-ignore
 /tests export-ignore


### PR DESCRIPTION
we are shipping `owlbot.py` and `.OwlBot.yaml` with the `google/common-protos` package. Let's ignore them instead.